### PR TITLE
Reduce crate size by adding 'include' directive to manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/tiby312/broccoli"
 keywords = ["tree", "kdtree","broadphase","space-partitioning","no_std"]
 readme = "README.md"
 edition = "2018"
+include = ["src/**/*", "LICENSE-MIT", "README.md", "!**/build/**/*"]
 
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/tiby312/broccoli"
 keywords = ["tree", "kdtree","broadphase","space-partitioning","no_std"]
 readme = "README.md"
 edition = "2018"
-include = ["src/**/*", "LICENSE-MIT", "README.md", "!**/build/**/*"]
+include = ["src/**/*", "LICENSE-MIT", "README.md"]
 
 
 [workspace]


### PR DESCRIPTION
Please let me know if there is anything else you would
rather want included to make this PR mergeable.

Here is the output of `cargo diet`

```
➜  broccoli git:(master) cargo diet
┌───────────────────────────────────────────┬─────────────┐
│ Removed File                              │ Size (Byte) │
├───────────────────────────────────────────┼─────────────┤
│ .travis.yml                               │          38 │
│ make_dep_graph.sh                         │          63 │
│ report/deploy.sh                          │          66 │
│ .gitignore                                │         119 │
│ report/book.toml                          │         141 │
│ report/README.md                          │         145 │
│ report/perf.sh                            │         229 │
│ report/generate.sh                        │         308 │
│ report/src/ch8-bounds-checking.md         │         405 │
│ report/src/ch7-parallelism.md             │         608 │
│ report/src/overview.md                    │         699 │
│ examples/rect.rs                          │         730 │
│ examples/indirection.rs                   │         748 │
│ examples/multi_rect.rs                    │         773 │
│ examples/collision.rs                     │         781 │
│ report/src/SUMMARY.md                     │         797 │
│ examples/raycast.rs                       │         854 │
│ examples/knearest.rs                      │        1080 │
│ examples/collect.rs                       │        1188 │
│ report/src/ch13-how-to-make-aabb.md       │        1465 │
│ report/src/ch9-primitive-types.md         │        1582 │
│ report/src/ch6-choosing-optimal-height.md │        1728 │
│ report/src/ch3-level-analysis.md          │        1926 │
│ report/src/ch14-code-layout.md            │        2645 │
│ tests/broccoli_test.rs                    │        3649 │
│ report/src/ch5-tree-data-layout.md        │        3655 │
│ report/src/ch0-analysis-method.md         │        4153 │
│ tests/test.rs                             │        4364 │
│ report/src/ch15-general-thoughts.md       │        6360 │
│ report/src/ch4-aabb-data-layout.md        │        6776 │
│ report/src/ch11-algorithm-in-depth.md     │        7270 │
│ report/src/ch2-construction-vs-query.md   │        7804 │
│ report/src/ch10-api-design.md             │        7935 │
│ report/src/ch12-improvements.md           │        8628 │
│ report/src/ch1-broccoli-vs-other.md       │        8820 │
│ report/src/chxx.md                        │       10885 │
│ assets/logo.png                           │       13326 │
│ assets/screenshot.gif                     │     2026532 │
└───────────────────────────────────────────┴─────────────┘
Saved 93% or 2.2 MB in 41 files (of 2.3 MB and 67 files in entire crate)
```