### PR TITLE
Knearest panics

### DIFF
--- a/tests/reproduction.rs
+++ b/tests/reproduction.rs
@@ -1,0 +1,30 @@
+#[test]
+fn knearest_repro() {
+    use axgeom::*;
+    use broccoli::*;
+
+    let mut repro = [
+        bbox(rect(729.75f32, 731.25, -0.75, 0.75), vec2(730.5, 0.)),
+        bbox(rect(1517.25, 1518.75, -0.75, 0.75), vec2(1518., 0.)),
+    ];
+
+    let mut tree = broccoli::new(&mut repro);
+
+    let mut handler = broccoli::helper::knearest_from_closure(
+        &tree,
+        (),
+        |_, point, a| Some(a.rect.distance_squared_to_point(point).unwrap_or(0.)),
+        |_, point, a| a.inner.distance_squared_to_point(point),
+        |_, point, a| (point.x - a).powi(2),
+        |_, point, a| (point.y - a).powi(2),
+    );
+
+    let mut res = tree.k_nearest_mut(vec2(627.0, 727.5), 1, &mut handler);
+
+    assert_eq!(res.len(), 1);
+    assert_eq!(res.total_len(), 1);
+
+    use broccoli::query::KnearestResult;
+    let r: &[KnearestResult<_>] = res.iter().next().unwrap();
+    assert_eq!(r.len(), 1);
+}


### PR DESCRIPTION
I was trying to use `k_nearest` (copy pasted version of `k_nearest_mut` with references swapped) and my game started to panic with errors that seemed to be caused by overflow (was running the game in release mode). I swapped to `k_nearest_mut` and had same issue.

I then printed the result of `get_elements` and the point I was trying to find nearest for, transformed result to code form (using `bbox` and `rect`) and made test into `broccoli` code base which was still failing. Curiously it didn't fail if I used `default_rect_knearest`.

I then reduced the test from 6132 `bbox`:es to only 2 and that reduced test is now this PR.